### PR TITLE
IMU quaternion (rmat phase out)

### DIFF
--- a/src/main/build/debug.c
+++ b/src/main/build/debug.c
@@ -57,4 +57,5 @@ const char * const debugModeNames[DEBUG_COUNT] = {
     "LIDAR_TF",
     "CORE_TEMP",
     "RUNAWAY_TAKEOFF",
+    "IMU",
 };

--- a/src/main/build/debug.h
+++ b/src/main/build/debug.h
@@ -75,6 +75,7 @@ typedef enum {
     DEBUG_LIDAR_TF,
     DEBUG_CORE_TEMP,
     DEBUG_RUNAWAY_TAKEOFF,
+    DEBUG_IMU,
     DEBUG_COUNT
 } debugType_e;
 

--- a/src/main/common/maths.c
+++ b/src/main/common/maths.c
@@ -345,3 +345,117 @@ int16_t qMultiply(fix12_t q, int16_t input) {
 fix12_t  qConstruct(int16_t num, int16_t den) {
     return (num << 12) / den;
 }
+
+// quaternions
+void quaternionTransformVectorBodyToEarth(quaternion *qVector, quaternion *qReference) {
+    quaternion qVectorBuffer, qReferenceConjugate;
+    qVector->w = 0;
+
+    quaternionCopy(qVector, &qVectorBuffer);
+    quaternionConjugate(qReference, &qReferenceConjugate);
+    quaternionMultiply(qReference, &qVectorBuffer, &qVectorBuffer);
+    quaternionMultiply(&qVectorBuffer, &qReferenceConjugate, qVector);
+}
+
+void quaternionTransformVectorEarthToBody(quaternion *qVector, quaternion *qReference) {
+    quaternion qVectorBuffer, qReferenceConjugate;
+    qVector->w = 0;
+
+    quaternionCopy(qVector, &qVectorBuffer);
+    quaternionConjugate(qReference, &qReferenceConjugate);
+    quaternionMultiply(&qReferenceConjugate, &qVectorBuffer, &qVectorBuffer);
+    quaternionMultiply(&qVectorBuffer, qReference, qVector);
+}
+
+void quaternionComputeProducts(quaternion *qIn, quaternionProducts *qPout) {
+    qPout->ww = qIn->w * qIn->w;
+    qPout->wx = qIn->w * qIn->x;
+    qPout->wy = qIn->w * qIn->y;
+    qPout->wz = qIn->w * qIn->z;
+    qPout->xx = qIn->x * qIn->x;
+    qPout->xy = qIn->x * qIn->y;
+    qPout->xz = qIn->x * qIn->z;
+    qPout->yy = qIn->y * qIn->y;
+    qPout->yz = qIn->y * qIn->z;
+    qPout->zz = qIn->z * qIn->z;
+}
+
+void quaternionMultiply(quaternion *l, quaternion *r, quaternion *o) {
+    const float w = l->w * r->w - l->x * r->x - l->y * r->y - l->z * r->z;
+    const float x = l->w * r->x + l->x * r->w + l->y * r->z - l->z * r->y;
+    const float y = l->w * r->y - l->x * r->z + l->y * r->w + l->z * r->x;
+    const float z = l->w * r->z + l->x * r->y - l->y * r->x + l->z * r->w;
+    o->w = w;
+    o->x = x;
+    o->y = y;
+    o->z = z;
+}
+
+void quaternionNormalize(quaternion *q) {
+    float modulus = sqrtf(q->w * q->w + q->x * q->x + q->y * q->y + q->z * q->z);
+    if (modulus == 0) {
+      modulus = 0.0000001;
+    }
+    q->w /= modulus;
+    q->x /= modulus;
+    q->y /= modulus;
+    q->z /= modulus;
+}
+
+void quaternionAdd(quaternion *l, quaternion *r, quaternion *o) {
+    o->w = l->w + r->w;
+    o->x = l->x + r->x;
+    o->y = l->y + r->y;
+    o->z = l->z + r->z;
+}
+
+void quaternionCopy(quaternion *s, quaternion *d) {
+    d->w = s->w;
+    d->x = s->x;
+    d->y = s->y;
+    d->z = s->z;
+}
+
+void quaternionInverse(quaternion *i, quaternion *o) {
+    float norm = i->w * i->w + i->x * i->x + i->y * i->y + i->z * i->z;
+    if (norm == 0) {
+        norm = 0.0000001;
+    }
+    o->w = i->w / norm;
+    o->x = i->x * -1 / norm;
+    o->y = i->y * -1 / norm;
+    o->z = i->z * -1 / norm;
+}
+
+void quaternionConjugate(quaternion *i, quaternion *o) {
+    o->w = i->w;
+    o->x = i->x * -1;
+    o->y = i->y * -1;
+    o->z = i->z * -1;
+}
+
+float quaternionDotProduct(quaternion *l, quaternion *r) {
+    return(l->w * r->w + l->x * r->x + l->y * r->y + l->z * r->z);
+}
+
+float quaternionNorm(quaternion *q) {
+    return(q->w * q->w + q->x * q->x + q->y * q->y + q->z * q->z);
+}
+
+float quaternionModulus(quaternion *q) {
+    return(sqrtf(q->w * q->w + q->x * q->x + q->y * q->y + q->z * q->z));
+}
+
+void quaternionInitQuaternion(quaternion *i) {
+    i->w = 1;
+    i->x = 0;
+    i->y = 0;
+    i->z = 0;
+}
+
+void quaternionInitVector(quaternion *i) {
+    i->w = 0;
+    i->x = 0;
+    i->y = 0;
+    i->z = 0;
+}

--- a/src/main/common/maths.h
+++ b/src/main/common/maths.h
@@ -28,6 +28,7 @@
 
 // Use floating point M_PI instead explicitly.
 #define M_PIf       3.14159265358979323846f
+#define M_PI_HALFf  3.14159265358979323846f/2
 
 #define RAD    (M_PIf / 180.0f)
 #define DEGREES_TO_DECIDEGREES(angle) (angle * 10)
@@ -150,3 +151,30 @@ static inline float constrainf(float amt, float low, float high)
     else
         return amt;
 }
+
+// quaternions
+typedef struct {
+    float w,x,y,z;
+} quaternion;
+#define QUATERNION_INITIALIZE   {.w=1, .x=0, .y=0,.z=0}
+#define VECTOR_INITIALIZE       {.w=0, .x=0, .y=0,.z=0}
+
+typedef struct {
+    float ww,wx,wy,wz,xx,xy,xz,yy,yz,zz;
+} quaternionProducts;
+#define QUATERNION_PRODUCTS_INITIALIZE  {.ww=1, .wx=0, .wy=0, .wz=0, .xx=0, .xy=0, .xz=0, .yy=0, .yz=0, .zz=0}
+
+void quaternionComputeProducts(quaternion *qIn, quaternionProducts *qPout);
+void quaternionTransformVectorBodyToEarth(quaternion *qVector, quaternion *qReference);
+void quaternionTransformVectorEarthToBody(quaternion *qVector, quaternion *qReference);
+void quaternionMultiply(quaternion *l, quaternion *r, quaternion *o);
+void quaternionNormalize(quaternion *q);
+void quaternionAdd(quaternion *l, quaternion *r, quaternion *o);
+void quaternionCopy(quaternion *s, quaternion *d);
+void quaternionInverse(quaternion *i, quaternion *o);
+void quaternionConjugate(quaternion *i, quaternion *o);
+float quaternionDotProduct(quaternion *l, quaternion *r);
+float quaternionNorm(quaternion *q);
+float quaternionModulus(quaternion *q);
+void quaternionInitQuaternion(quaternion *i);
+void quaternionInitVector(quaternion *i);

--- a/src/main/fc/fc_core.c
+++ b/src/main/fc/fc_core.c
@@ -569,7 +569,7 @@ bool processRx(timeUs_t currentTimeUs)
                 && (fabsf(axisPIDSum[FD_PITCH]) < RUNAWAY_TAKEOFF_DEACTIVATE_PIDSUM_LIMIT)
                 && (fabsf(axisPIDSum[FD_ROLL]) < RUNAWAY_TAKEOFF_DEACTIVATE_PIDSUM_LIMIT)
                 && (fabsf(axisPIDSum[FD_YAW]) < RUNAWAY_TAKEOFF_DEACTIVATE_PIDSUM_LIMIT)) {
-                
+
                 inStableFlight = true;
                 if (runawayTakeoffDeactivateUs == 0) {
                     runawayTakeoffDeactivateUs = currentTimeUs;
@@ -702,11 +702,8 @@ bool processRx(timeUs_t currentTimeUs)
 
     if (FLIGHT_MODE(ANGLE_MODE) || FLIGHT_MODE(HORIZON_MODE)) {
         LED1_ON;
-        // increase frequency of attitude task to reduce drift when in angle or horizon mode
-        rescheduleTask(TASK_ATTITUDE, TASK_PERIOD_HZ(500));
     } else {
         LED1_OFF;
-        rescheduleTask(TASK_ATTITUDE, TASK_PERIOD_HZ(100));
     }
 
     if (!IS_RC_MODE_ACTIVE(BOXPREARM) && ARMING_FLAG(WAS_ARMED_WITH_PREARM)) {

--- a/src/main/fc/fc_rc.c
+++ b/src/main/fc/fc_rc.c
@@ -342,21 +342,22 @@ void updateRcCommands(void)
             }
         }
     }
-    if (FLIGHT_MODE(HEADFREE_MODE)) {
-        static t_fp_vector_def  rcCommandBuff;
 
-        rcCommandBuff.X = rcCommand[ROLL];
-        rcCommandBuff.Y = rcCommand[PITCH];
-        if ((!FLIGHT_MODE(ANGLE_MODE)&&(!FLIGHT_MODE(HORIZON_MODE)))) {
-            rcCommandBuff.Z = rcCommand[YAW];
+    if (FLIGHT_MODE(HEADFREE_MODE)) {
+        static quaternion  vRcCommand;
+        // in ANGLE_MODE and HORIZON_MODE  yaw rotation is bodyframe bound, in ACRO_MODE it is earthframe bound
+        vRcCommand.x = rcCommand[ROLL];
+        vRcCommand.y = rcCommand[PITCH];
+        if ((!FLIGHT_MODE(ANGLE_MODE) && (!FLIGHT_MODE(HORIZON_MODE)))) {
+            vRcCommand.z = rcCommand[YAW];
         } else {
-            rcCommandBuff.Z = 0;
+            vRcCommand.z = 0;
         }
-        imuQuaternionHeadfreeTransformVectorEarthToBody(&rcCommandBuff);
-        rcCommand[ROLL] = rcCommandBuff.X;
-        rcCommand[PITCH] = rcCommandBuff.Y;
-        if ((!FLIGHT_MODE(ANGLE_MODE)&&(!FLIGHT_MODE(HORIZON_MODE)))) {
-            rcCommand[YAW] = rcCommandBuff.Z;
+        quaternionTransformVectorEarthToBody(&vRcCommand, &qHeadfree);
+        rcCommand[ROLL] = vRcCommand.x;
+        rcCommand[PITCH] = vRcCommand.y;
+        if ((!FLIGHT_MODE(ANGLE_MODE) && (!FLIGHT_MODE(HORIZON_MODE)))) {
+            rcCommand[YAW] = vRcCommand.z;
         }
     }
 }

--- a/src/main/fc/fc_tasks.c
+++ b/src/main/fc/fc_tasks.c
@@ -441,8 +441,8 @@ cfTask_t cfTasks[TASK_COUNT] = {
     [TASK_ATTITUDE] = {
         .taskName = "ATTITUDE",
         .taskFunc = imuUpdateAttitude,
-        .desiredPeriod = TASK_PERIOD_HZ(100),
-        .staticPriority = TASK_PRIORITY_MEDIUM,
+        .desiredPeriod = TASK_PERIOD_HZ(200),
+        .staticPriority = TASK_PRIORITY_HIGH,
     },
 
     [TASK_RX] = {

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -40,6 +40,7 @@
 #include "flight/pid.h"
 
 #include "io/gps.h"
+#include "io/beeper.h"
 
 #include "sensors/acceleration.h"
 #include "sensors/barometer.h"
@@ -68,13 +69,6 @@ static bool imuUpdated = false;
 
 #endif
 
-// the limit (in degrees/second) beyond which we stop integrating
-// omega_I. At larger spin rates the DCM PI controller can get 'dizzy'
-// which results in false gyro drift. See
-// http://gentlenav.googlecode.com/files/fastRotations.pdf
-
-#define SPIN_RATE_LIMIT 20
-
 int32_t accSum[XYZ_AXIS_COUNT];
 
 uint32_t accTimeSum = 0;        // keep track for integration of acc
@@ -87,14 +81,12 @@ static float smallAngleCosZ = 0;
 
 static imuRuntimeConfig_t imuRuntimeConfig;
 
-STATIC_UNIT_TESTED float rMat[3][3];
-
 // quaternion of sensor frame relative to earth frame
-STATIC_UNIT_TESTED quaternion q = QUATERNION_INITIALIZE;
-STATIC_UNIT_TESTED quaternionProducts qP = QUATERNION_PRODUCTS_INITIALIZE;
+STATIC_UNIT_TESTED quaternion qAttitude = QUATERNION_INITIALIZE;
+STATIC_UNIT_TESTED quaternionProducts qpAttitude = QUATERNION_PRODUCTS_INITIALIZE;
 // headfree quaternions
-quaternion headfree = QUATERNION_INITIALIZE;
-quaternion offset = QUATERNION_INITIALIZE;
+quaternion qHeadfree = QUATERNION_INITIALIZE;
+quaternion qOffset = QUATERNION_INITIALIZE;
 
 // absolute angle inclination in multiple of 0.1 degree    180 deg = 1800
 attitudeEulerAngles_t attitude = EULER_INITIALIZE;
@@ -102,37 +94,15 @@ attitudeEulerAngles_t attitude = EULER_INITIALIZE;
 PG_REGISTER_WITH_RESET_TEMPLATE(imuConfig_t, imuConfig, PG_IMU_CONFIG, 0);
 
 PG_RESET_TEMPLATE(imuConfig_t, imuConfig,
-    .dcm_kp = 2500,                // 1.0 * 10000
-    .dcm_ki = 0,                   // 0.003 * 10000
+    .dcm_kp = 7013,
+    .dcm_ki = 13,
     .small_angle = 25,
     .accDeadband = {.xy = 40, .z= 40},
     .acc_unarmedcal = 1
 );
 
-STATIC_UNIT_TESTED void imuComputeRotationMatrix(void){
-    imuQuaternionComputeProducts(&q, &qP);
 
-    rMat[0][0] = 1.0f - 2.0f * qP.yy - 2.0f * qP.zz;
-    rMat[0][1] = 2.0f * (qP.xy + -qP.wz);
-    rMat[0][2] = 2.0f * (qP.xz - -qP.wy);
-
-    rMat[1][0] = 2.0f * (qP.xy - -qP.wz);
-    rMat[1][1] = 1.0f - 2.0f * qP.xx - 2.0f * qP.zz;
-    rMat[1][2] = 2.0f * (qP.yz + -qP.wx);
-
-    rMat[2][0] = 2.0f * (qP.xz + -qP.wy);
-    rMat[2][1] = 2.0f * (qP.yz - -qP.wx);
-    rMat[2][2] = 1.0f - 2.0f * qP.xx - 2.0f * qP.yy;
-
-#if defined(SIMULATOR_BUILD) && defined(SKIP_IMU_CALC) && !defined(SET_IMU_FROM_EULER)
-    rMat[1][0] = -2.0f * (qP.xy - -qP.wz);
-    rMat[2][0] = -2.0f * (qP.xz + -qP.wy);
-#endif
-}
-
-/*
-* Calculate RC time constant used in the accZ lpf.
-*/
+// calculate RC time constant used in the accZ lpf.
 static float calculateAccZLowPassFilterRCTimeConstant(float accz_lpf_cutoff)
 {
     return 0.5f / (M_PIf * accz_lpf_cutoff);
@@ -159,7 +129,6 @@ void imuInit(void)
     smallAngleCosZ = cos_approx(degreesToRadians(imuRuntimeConfig.small_angle));
     accVelScale = 9.80665f / acc.dev.acc_1G / 10000.0f;
 
-    imuComputeRotationMatrix();
 
 #if defined(SIMULATOR_BUILD) && defined(SIMULATOR_MULTITHREAD)
     if (pthread_mutex_init(&imuUpdateLock, NULL) != 0) {
@@ -178,49 +147,36 @@ void imuResetAccelerationSum(void)
 }
 
 #if defined(USE_ALT_HOLD)
-static void imuTransformVectorBodyToEarth(t_fp_vector * v)
-{
-    // From body frame to earth frame
-    const float x = rMat[0][0] * v->V.X + rMat[0][1] * v->V.Y + rMat[0][2] * v->V.Z;
-    const float y = rMat[1][0] * v->V.X + rMat[1][1] * v->V.Y + rMat[1][2] * v->V.Z;
-    const float z = rMat[2][0] * v->V.X + rMat[2][1] * v->V.Y + rMat[2][2] * v->V.Z;
-
-    v->V.X = x;
-    v->V.Y = -y;
-    v->V.Z = z;
-}
-
 // rotate acc into Earth frame and calculate acceleration in it
 static void imuCalculateAcceleration(timeDelta_t deltaT)
 {
-    static int32_t accZoffset = 0;
+    static float accZoffset = 0;
     static float accz_smooth = 0;
 
     // deltaT is measured in us ticks
     const float dT = (float)deltaT * 1e-6f;
 
-    t_fp_vector accel_ned;
-    accel_ned.V.X = acc.accADC[X];
-    accel_ned.V.Y = acc.accADC[Y];
-    accel_ned.V.Z = acc.accADC[Z];
-
-    imuTransformVectorBodyToEarth(&accel_ned);
+    quaternion accel_ned;
+    accel_ned.x = acc.accADC[X];
+    accel_ned.y = acc.accADC[Y];
+    accel_ned.z = acc.accADC[Z];
+    quaternionTransformVectorBodyToEarth(&accel_ned, &qAttitude);
 
     if (imuRuntimeConfig.acc_unarmedcal == 1) {
         if (!ARMING_FLAG(ARMED)) {
             accZoffset -= accZoffset / 64;
-            accZoffset += accel_ned.V.Z;
+            accZoffset += accel_ned.z;
         }
-        accel_ned.V.Z -= accZoffset / 64;  // compensate for gravitation on z-axis
+        accel_ned.z -= accZoffset / 64;  // compensate for gravitation on z-axis
     } else {
-        accel_ned.V.Z -= acc.dev.acc_1G;
+        accel_ned.z -= acc.dev.acc_1G;
     }
 
-    accz_smooth = accz_smooth + (dT / (fc_acc + dT)) * (accel_ned.V.Z - accz_smooth); // low pass filter
+    accz_smooth = accz_smooth + (dT / (fc_acc + dT)) * (accel_ned.z - accz_smooth); // low pass filter
 
     // apply Deadband to reduce integration drift and vibration influence
-    accSum[X] += applyDeadband(lrintf(accel_ned.V.X), imuRuntimeConfig.accDeadband.xy);
-    accSum[Y] += applyDeadband(lrintf(accel_ned.V.Y), imuRuntimeConfig.accDeadband.xy);
+    accSum[X] += applyDeadband(lrintf(accel_ned.x), imuRuntimeConfig.accDeadband.xy);
+    accSum[Y] += applyDeadband(lrintf(accel_ned.y), imuRuntimeConfig.accDeadband.xy);
     accSum[Z] += applyDeadband(lrintf(accz_smooth), imuRuntimeConfig.accDeadband.z);
 
     // sum up Values for later integration to get velocity and distance
@@ -229,189 +185,155 @@ static void imuCalculateAcceleration(timeDelta_t deltaT)
 }
 #endif // USE_ALT_HOLD
 
-static float invSqrt(float x)
-{
-    return 1.0f / sqrtf(x);
-}
-
-static bool imuUseFastGains(void)
-{
-    return !ARMING_FLAG(ARMED) && millis() < 20000;
-}
-
-static float imuGetPGainScaleFactor(void)
-{
-    if (imuUseFastGains()) {
-        return 10.0f;
+static float imuUseFastGains(void) {
+   if (!ARMING_FLAG(ARMED)) {
+        return (17.0f);
     }
     else {
-        return 1.0f;
+        if (isBeeperOn()) {
+          // reduce PI scaling (onboard beeper influences vAcc)
+          return (0.17f);
+        } else {
+          return (1.0f);
+        }
     }
 }
 
-static void imuMahonyAHRSupdate(float dt, float gx, float gy, float gz,
-                                bool useAcc, float ax, float ay, float az,
-                                bool useMag, float mx, float my, float mz,
-                                bool useYaw, float yawError)
-{
-    static float integralFBx = 0.0f,  integralFBy = 0.0f, integralFBz = 0.0f;    // integral error terms scaled by Ki
+static void imuMahonyAHRSupdate(float dt, quaternion *vGyro, bool useAcc, quaternion *vAcc, bool useMag, quaternion *vMag, bool useYaw, float yawError) {
+    quaternion vKpKi = VECTOR_INITIALIZE;
+    quaternion vError = VECTOR_INITIALIZE;
+    static quaternion vIntegralFB = VECTOR_INITIALIZE;
+    quaternion qBuff, qDiff;
 
-    // Calculate general spin rate (rad/s)
-    const float spin_rate = sqrtf(sq(gx) + sq(gy) + sq(gz));
-
-    // Use raw heading error (from GPS or whatever else)
-    float ex = 0, ey = 0, ez = 0;
+    // use raw heading error (from GPS or whatever else)
     if (useYaw) {
         while (yawError >  M_PIf) yawError -= (2.0f * M_PIf);
         while (yawError < -M_PIf) yawError += (2.0f * M_PIf);
-        ez += sin_approx(yawError / 2.0f);
+        vError.z += sin_approx(yawError / 2.0f);
     }
 
 #ifdef USE_MAG
-    // Use measured magnetic field vector
-    float recipMagNorm = sq(mx) + sq(my) + sq(mz);
-    if (useMag && recipMagNorm > 0.01f) {
-        // Normalise magnetometer measurement
-        recipMagNorm = invSqrt(recipMagNorm);
-        mx *= recipMagNorm;
-        my *= recipMagNorm;
-        mz *= recipMagNorm;
+    // For magnetometer correction we make an assumption that magnetic field is perpendicular to gravity (ignore Z-component in EF).
+    // This way magnetic field will only affect heading and wont mess roll/pitch angles
+    if (useMag) {
+        if (compassIsHealthy(vMag)) {
+            quaternionNormalize(vMag);
 
-        // For magnetometer correction we make an assumption that magnetic field is perpendicular to gravity (ignore Z-component in EF).
-        // This way magnetic field will only affect heading and wont mess roll/pitch angles
+            // (hx; hy; 0) - measured mag field vector in EF (assuming Z-component is zero)
+            // (bx; 0; 0) - reference mag field vector heading due North in EF (assuming Z-component is zero)
+            const float hx = (1.0f - 2.0f * qpAttitude.yy - 2.0f * qpAttitude.zz) * vMag->x + (2.0f * (qpAttitude.xy + -qpAttitude.wz)) * vMag->y + (2.0f * (qpAttitude.xz - -qpAttitude.wy)) * vMag->z;
+            const float hy = (2.0f * (qpAttitude.xy - -qpAttitude.wz)) * vMag->x + (1.0f - 2.0f * qpAttitude.xx - 2.0f * qpAttitude.zz) * vMag->y + (2.0f * (qpAttitude.yz + -qpAttitude.wx)) * vMag->z;
+            const float bx = sqrtf(sq(hx) + sq(hy));
 
-        // (hx; hy; 0) - measured mag field vector in EF (assuming Z-component is zero)
-        // (bx; 0; 0) - reference mag field vector heading due North in EF (assuming Z-component is zero)
-        const float hx = rMat[0][0] * mx + rMat[0][1] * my + rMat[0][2] * mz;
-        const float hy = rMat[1][0] * mx + rMat[1][1] * my + rMat[1][2] * mz;
-        const float bx = sqrtf(hx * hx + hy * hy);
+            // magnetometer error is cross product between estimated magnetic north and measured magnetic north (calculated in EF)
+            const float ez_ef = -(hy * bx);
 
-        // magnetometer error is cross product between estimated magnetic north and measured magnetic north (calculated in EF)
-        const float ez_ef = -(hy * bx);
-
-        // Rotate mag error vector back to BF and accumulate
-        ex += rMat[2][0] * ez_ef;
-        ey += rMat[2][1] * ez_ef;
-        ez += rMat[2][2] * ez_ef;
+            // Rotate mag error vector back to BF and accumulate
+            vError.x += (2.0f * (qpAttitude.xz + -qpAttitude.wy)) * ez_ef;
+            vError.y += (2.0f * (qpAttitude.yz - -qpAttitude.wx)) * ez_ef;
+            vError.z += (1.0f - 2.0f * qpAttitude.xx - 2.0f * qpAttitude.yy) * ez_ef;
+        }
     }
 #else
     UNUSED(useMag);
-    UNUSED(mx);
-    UNUSED(my);
-    UNUSED(mz);
+    UNUSED(vMag);
 #endif
 
-    // Use measured acceleration vector
-    float recipAccNorm = sq(ax) + sq(ay) + sq(az);
-    if (useAcc && recipAccNorm > 0.01f) {
-        // Normalise accelerometer measurement
-        recipAccNorm = invSqrt(recipAccNorm);
-        ax *= recipAccNorm;
-        ay *= recipAccNorm;
-        az *= recipAccNorm;
-
-        // Error is sum of cross product between estimated direction and measured direction of gravity
-        ex += (ay * rMat[2][2] - az * rMat[2][1]);
-        ey += (az * rMat[2][0] - ax * rMat[2][2]);
-        ez += (ax * rMat[2][1] - ay * rMat[2][0]);
-    }
-
-    // Compute and apply integral feedback if enabled
-    if (imuRuntimeConfig.dcm_ki > 0.0f) {
-        // Stop integrating if spinning beyond the certain limit
-        if (spin_rate < DEGREES_TO_RADIANS(SPIN_RATE_LIMIT)) {
-            const float dcmKiGain = imuRuntimeConfig.dcm_ki;
-            integralFBx += dcmKiGain * ex * dt;    // integral error scaled by Ki
-            integralFBy += dcmKiGain * ey * dt;
-            integralFBz += dcmKiGain * ez * dt;
+    //debug
+    DEBUG_SET(DEBUG_IMU, DEBUG_IMU_VACCMODULUS, lrintf((quaternionModulus(vAcc)/ acc.dev.acc_1G) * 1000));
+    if (useAcc) {
+        if (accIsHealthy(vAcc)) {
+            quaternionNormalize(vAcc);
+            // Error is sum of cross product between estimated direction and measured direction of gravity
+            vError.x += (vAcc->y * (1.0f - 2.0f * qpAttitude.xx - 2.0f * qpAttitude.yy) - vAcc->z * (2.0f * (qpAttitude.yz - -qpAttitude.wx)));
+            vError.y += (vAcc->z * (2.0f * (qpAttitude.xz + -qpAttitude.wy)) - vAcc->x * (1.0f - 2.0f * qpAttitude.xx - 2.0f * qpAttitude.yy));
+            vError.z += (vAcc->x * (2.0f * (qpAttitude.yz - -qpAttitude.wx)) - vAcc->y * (2.0f * (qpAttitude.xz + -qpAttitude.wy)));
         }
-    } else {
-        integralFBx = 0.0f;    // prevent integral windup
-        integralFBy = 0.0f;
-        integralFBz = 0.0f;
     }
 
-    // Calculate kP gain. If we are acquiring initial attitude (not armed and within 20 sec from powerup) scale the kP to converge faster
-    const float dcmKpGain = imuRuntimeConfig.dcm_kp * imuGetPGainScaleFactor();
+    // scale dcm to converge faster (if not armed)
+    const float dcmKpGain = imuRuntimeConfig.dcm_kp * imuUseFastGains();
+    const float dcmKiGain = imuRuntimeConfig.dcm_ki * imuUseFastGains();
 
-    // Apply proportional and integral feedback
-    gx += dcmKpGain * ex + integralFBx;
-    gy += dcmKpGain * ey + integralFBy;
-    gz += dcmKpGain * ez + integralFBz;
+    // calculate integral feedback
+    if (imuRuntimeConfig.dcm_ki > 0.0f) {
+        vIntegralFB.x += dcmKiGain * vError.x * dt;
+        vIntegralFB.y += dcmKiGain * vError.y * dt;
+        vIntegralFB.z += dcmKiGain * vError.z * dt;
+    } else {
+        quaternionInitVector(&vIntegralFB);
+    }
 
-    // Integrate rate of change of quaternion
-    gx *= (0.5f * dt);
-    gy *= (0.5f * dt);
-    gz *= (0.5f * dt);
+    // apply proportional and integral feedback
+    vKpKi.x += dcmKpGain * vError.x + vIntegralFB.x;
+    vKpKi.y += dcmKpGain * vError.y + vIntegralFB.y;
+    vKpKi.z += dcmKpGain * vError.z + vIntegralFB.z;
 
-    quaternion buffer;
-    buffer.w = q.w;
-    buffer.x = q.x;
-    buffer.y = q.y;
-    buffer.z = q.z;
+    // vGyro integration
+    // PCDM Acta Mech 224, 3091–3109 (2013)
+    const float vGyroModulus = quaternionModulus(vGyro);
+    // reduce gyro noise integration integrate only above vGyroStdDevModulus
+    if (vGyroModulus > vGyroStdDevModulus) {
+        qDiff.w = cosf(vGyroModulus * 0.5f * dt);
+        qDiff.x = sinf(vGyroModulus * 0.5f * dt) * (vGyro->x / vGyroModulus);
+        qDiff.y = sinf(vGyroModulus * 0.5f * dt) * (vGyro->y / vGyroModulus);
+        qDiff.z = sinf(vGyroModulus * 0.5f * dt) * (vGyro->z / vGyroModulus);
+        quaternionMultiply(&qAttitude, &qDiff, &qAttitude);
+    }
 
-    q.w += (-buffer.x * gx - buffer.y * gy - buffer.z * gz);
-    q.x += (+buffer.w * gx + buffer.y * gz - buffer.z * gy);
-    q.y += (+buffer.w * gy - buffer.x * gz + buffer.z * gx);
-    q.z += (+buffer.w * gz + buffer.x * gy - buffer.y * gx);
+    // vKpKi integration
+    // Euler integration (q(n+1) is determined by a first-order Taylor expansion) (old bf method adapted)
+    const float vKpKiModulus = quaternionModulus(&vKpKi);
+    if (vKpKiModulus > 0.003f) {
+        qDiff.w = 0;
+        qDiff.x = vKpKi.x * 0.5f * dt;
+        qDiff.y = vKpKi.y * 0.5f * dt;
+        qDiff.z = vKpKi.z * 0.5f * dt;
+        quaternionMultiply(&qAttitude, &qDiff, &qBuff);
+        quaternionAdd(&qAttitude, &qBuff, &qAttitude);
+        quaternionNormalize(&qAttitude);
+    }
 
-    // Normalise quaternion
-    float recipNorm = invSqrt(sq(q.w) + sq(q.x) + sq(q.y) + sq(q.z));
-    q.w *= recipNorm;
-    q.x *= recipNorm;
-    q.y *= recipNorm;
-    q.z *= recipNorm;
+    // compute caching products
+    quaternionComputeProducts(&qAttitude, &qpAttitude);
 
-    // Pre-compute rotation matrix from quaternion
-    imuComputeRotationMatrix();
+    //debug
+    DEBUG_SET(DEBUG_IMU, DEBUG_IMU_VGYROMODULUS, lrintf(vGyroModulus * 1000));
+    DEBUG_SET(DEBUG_IMU, DEBUG_IMU_VKPKIMODULUS, lrintf(vKpKiModulus * 1000));
+    //DEBUG_SET(DEBUG_IMU, DEBUG_IMU_FREE, lrintf(quaternionModulus(&qAttitude) * 1000));
+    DEBUG_SET(DEBUG_IMU, DEBUG_IMU_FREE, lrintf(vGyroStdDevModulus * 1000));
 }
 
-STATIC_UNIT_TESTED void imuUpdateEulerAngles(void)
-{
+STATIC_UNIT_TESTED void imuUpdateEulerAngles(void) {
     quaternionProducts buffer;
 
     if (FLIGHT_MODE(HEADFREE_MODE)) {
-       imuQuaternionComputeProducts(&headfree, &buffer);
-
-       attitude.values.roll = lrintf(atan2_approx((+2.0f * (buffer.wx + buffer.yz)), (+1.0f - 2.0f * (buffer.xx + buffer.yy))) * (1800.0f / M_PIf));
-       attitude.values.pitch = lrintf(((0.5f * M_PIf) - acos_approx(+2.0f * (buffer.wy - buffer.xz))) * (1800.0f / M_PIf));
-       attitude.values.yaw = lrintf((-atan2_approx((+2.0f * (buffer.wz + buffer.xy)), (+1.0f - 2.0f * (buffer.yy + buffer.zz))) * (1800.0f / M_PIf)));
+        quaternionMultiply(&qOffset, &qAttitude, &qHeadfree);
+        quaternionComputeProducts(&qHeadfree, &buffer);
     } else {
-       attitude.values.roll = lrintf(atan2_approx(rMat[2][1], rMat[2][2]) * (1800.0f / M_PIf));
-       attitude.values.pitch = lrintf(((0.5f * M_PIf) - acos_approx(-rMat[2][0])) * (1800.0f / M_PIf));
-       attitude.values.yaw = lrintf((-atan2_approx(rMat[1][0], rMat[0][0]) * (1800.0f / M_PIf)));
+        quaternionComputeProducts(&qAttitude, &buffer);
     }
 
-    if (attitude.values.yaw < 0)
-        attitude.values.yaw += 3600;
+    attitude.values.roll = lrintf(atan2_approx((+2.0f * (buffer.wx + buffer.yz)), (+1.0f - 2.0f * (buffer.xx + buffer.yy))) * (1800.0f / M_PIf));
+    attitude.values.pitch = lrintf(((0.5f * M_PIf) - acos_approx(+2.0f * (buffer.wy - buffer.xz))) * (1800.0f / M_PIf));
+    attitude.values.yaw = lrintf((-atan2_approx((+2.0f * (buffer.wz + buffer.xy)), (+1.0f - 2.0f * (buffer.yy + buffer.zz))) * (1800.0f / M_PIf)));
 
-    // Update small angle state
-    if (rMat[2][2] > smallAngleCosZ) {
+    if (attitude.values.yaw < 0) {
+        attitude.values.yaw += 3600;
+    }
+
+    if (getCosTiltAngle() > smallAngleCosZ) {
         ENABLE_STATE(SMALL_ANGLE);
     } else {
         DISABLE_STATE(SMALL_ANGLE);
     }
 }
 
-static bool imuIsAccelerometerHealthy(void)
-{
-    float accMagnitude = 0;
-    for (int axis = 0; axis < 3; axis++) {
-        const float a = acc.accADC[axis];
-        accMagnitude += a * a;
-    }
-
-    accMagnitude = accMagnitude * 100 / (sq((int32_t)acc.dev.acc_1G));
-
-    // Accept accel readings only in range 0.90g - 1.10g
-    return (81 < accMagnitude) && (accMagnitude < 121);
-}
-
 static void imuCalculateEstimatedAttitude(timeUs_t currentTimeUs)
 {
     static timeUs_t previousIMUUpdateTime;
     float rawYawError = 0;
-    bool useAcc = false;
+    bool useAcc = true;
     bool useMag = false;
     bool useYaw = false;
 
@@ -423,7 +345,7 @@ static void imuCalculateEstimatedAttitude(timeUs_t currentTimeUs)
     }
 
 #ifdef USE_MAG
-    if (sensors(SENSOR_MAG) && compassIsHealthy()) {
+    if (sensors(SENSOR_MAG)) {
         useMag = true;
     }
 #endif
@@ -447,20 +369,24 @@ static void imuCalculateEstimatedAttitude(timeUs_t currentTimeUs)
 //  printf("[imu]deltaT = %u, imuDeltaT = %u, currentTimeUs = %u, micros64_real = %lu\n", deltaT, imuDeltaT, currentTimeUs, micros64_real());
     deltaT = imuDeltaT;
 #endif
-    float gyroAverage[XYZ_AXIS_COUNT];
-    gyroGetAccumulationAverage(gyroAverage);
-    float accAverage[XYZ_AXIS_COUNT];
-    if (!accGetAccumulationAverage(accAverage)) {
+    // get sensor data
+    quaternion vGyroAverage;
+    gyroGetAverage(&vGyroAverage);
+
+    quaternion vAccAverage;
+    if (!accGetAverage(&vAccAverage)) {
         useAcc = false;
     }
-    imuMahonyAHRSupdate(deltaT * 1e-6f,
-                        DEGREES_TO_RADIANS(gyroAverage[X]), DEGREES_TO_RADIANS(gyroAverage[Y]), DEGREES_TO_RADIANS(gyroAverage[Z]),
-                        useAcc, accAverage[X], accAverage[Y], accAverage[Z],
-                        useMag, mag.magADC[X], mag.magADC[Y], mag.magADC[Z],
-                        useYaw, rawYawError);
 
+    quaternion vMagAverage;
+    if (useMag) {
+      compassGetAverage(&vMagAverage);
+    }
+
+    imuMahonyAHRSupdate(deltaT * 1e-6f, &vGyroAverage, useAcc, &vAccAverage, useMag, &vMagAverage, useYaw, rawYawError);
     imuUpdateEulerAngles();
 #endif
+
 #if defined(USE_ALT_HOLD)
     imuCalculateAcceleration(deltaT); // rotate acc vector into earth frame
 #endif
@@ -486,9 +412,8 @@ void imuUpdateAttitude(timeUs_t currentTimeUs)
     }
 }
 
-float getCosTiltAngle(void)
-{
-    return rMat[2][2];
+float getCosTiltAngle(void) {
+    return (1.0f - 2.0f * (qpAttitude.xx + qpAttitude.yy));
 }
 
 int16_t calculateThrottleAngleCorrection(uint8_t throttle_correction_value)
@@ -498,18 +423,17 @@ int16_t calculateThrottleAngleCorrection(uint8_t throttle_correction_value)
     * small angle < 0.86 deg
     * TODO: Define this small angle in config.
     */
-    if (rMat[2][2] <= 0.015f) {
+    if (getCosTiltAngle() <= 0.015f) {
         return 0;
     }
-    int angle = lrintf(acos_approx(rMat[2][2]) * throttleAngleScale);
+    int angle = lrintf(acos_approx(getCosTiltAngle()) * throttleAngleScale);
     if (angle > 900)
         angle = 900;
     return lrintf(throttle_correction_value * sin_approx(angle / (900.0f * M_PIf / 2.0f)));
 }
 
 #ifdef SIMULATOR_BUILD
-void imuSetAttitudeRPY(float roll, float pitch, float yaw)
-{
+void imuSetAttitudeRPY(float roll, float pitch, float yaw) {
     IMU_LOCK;
 
     attitude.values.roll = roll * 10;
@@ -518,24 +442,22 @@ void imuSetAttitudeRPY(float roll, float pitch, float yaw)
 
     IMU_UNLOCK;
 }
-void imuSetAttitudeQuat(float w, float x, float y, float z)
-{
+
+void imuSetAttitudeQuat(float w, float x, float y, float z) {
     IMU_LOCK;
 
-    q.w = w;
-    q.x = x;
-    q.y = y;
-    q.z = z;
+    qAttitude.w = w;
+    qAttitude.x = x;
+    qAttitude.y = y;
+    qAttitude.z = z;
 
-    imuComputeRotationMatrix();
     imuUpdateEulerAngles();
 
     IMU_UNLOCK;
 }
 #endif
 #if defined(SIMULATOR_BUILD) && defined(SIMULATOR_IMU_SYNC)
-void imuSetHasNewData(uint32_t dt)
-{
+void imuSetHasNewData(uint32_t dt) {
     IMU_LOCK;
 
     imuUpdated = true;
@@ -545,65 +467,17 @@ void imuSetHasNewData(uint32_t dt)
 }
 #endif
 
-void imuQuaternionComputeProducts(quaternion *quat, quaternionProducts *quatProd)
-{
-    quatProd->ww = quat->w * quat->w;
-    quatProd->wx = quat->w * quat->x;
-    quatProd->wy = quat->w * quat->y;
-    quatProd->wz = quat->w * quat->z;
-    quatProd->xx = quat->x * quat->x;
-    quatProd->xy = quat->x * quat->y;
-    quatProd->xz = quat->x * quat->z;
-    quatProd->yy = quat->y * quat->y;
-    quatProd->yz = quat->y * quat->z;
-    quatProd->zz = quat->z * quat->z;
-}
-
-bool imuQuaternionHeadfreeOffsetSet(void)
-{
-    if ((ABS(attitude.values.roll) < 450)  && (ABS(attitude.values.pitch) < 450)) {
-        const float yaw = -atan2_approx((+2.0f * (qP.wz + qP.xy)), (+1.0f - 2.0f * (qP.yy + qP.zz)));
-
-        offset.w = cos_approx(yaw/2);
-        offset.x = 0;
-        offset.y = 0;
-        offset.z = sin_approx(yaw/2);
-
-        return true;
+// HEADFREE HEADADJ allowed for tilt below 37°
+bool imuQuaternionHeadfreeOffsetSet(void) {
+      if ((ABS(getCosTiltAngle()) > 0.8f)) {
+        const float yawHalf = atan2_approx((+2.0f * (qpAttitude.wz + qpAttitude.xy)), (+1.0f - 2.0f * (qpAttitude.yy + qpAttitude.zz))) / 2.0f;
+        qOffset.w = cos_approx(yawHalf);
+        qOffset.x = 0;
+        qOffset.y = 0;
+        qOffset.z = sin_approx(yawHalf);
+        quaternionConjugate(&qOffset, &qOffset);
+        return (true);
     } else {
-        return false;
+        return (false);
     }
-}
-
-void imuQuaternionMultiplication(quaternion *q1, quaternion *q2, quaternion *result)
-{
-    const float A = (q1->w + q1->x) * (q2->w + q2->x);
-    const float B = (q1->z - q1->y) * (q2->y - q2->z);
-    const float C = (q1->w - q1->x) * (q2->y + q2->z);
-    const float D = (q1->y + q1->z) * (q2->w - q2->x);
-    const float E = (q1->x + q1->z) * (q2->x + q2->y);
-    const float F = (q1->x - q1->z) * (q2->x - q2->y);
-    const float G = (q1->w + q1->y) * (q2->w - q2->z);
-    const float H = (q1->w - q1->y) * (q2->w + q2->z);
-
-    result->w = B + (- E - F + G + H) / 2.0f;
-    result->x = A - (+ E + F + G + H) / 2.0f;
-    result->y = C + (+ E - F + G - H) / 2.0f;
-    result->z = D + (+ E - F - G + H) / 2.0f;
-}
-
-void imuQuaternionHeadfreeTransformVectorEarthToBody(t_fp_vector_def *v)
-{
-    quaternionProducts buffer;
-
-    imuQuaternionMultiplication(&offset, &q, &headfree);
-    imuQuaternionComputeProducts(&headfree, &buffer);
-
-    const float x = (buffer.ww + buffer.xx - buffer.yy - buffer.zz) * v->X + 2.0f * (buffer.xy + buffer.wz) * v->Y + 2.0f * (buffer.xz - buffer.wy) * v->Z;
-    const float y = 2.0f * (buffer.xy - buffer.wz) * v->X + (buffer.ww - buffer.xx + buffer.yy - buffer.zz) * v->Y + 2.0f * (buffer.yz + buffer.wx) * v->Z;
-    const float z = 2.0f * (buffer.xz + buffer.wy) * v->X + 2.0f * (buffer.yz - buffer.wx) * v->Y + (buffer.ww - buffer.xx - buffer.yy + buffer.zz) * v->Z;
-
-    v->X = x;
-    v->Y = y;
-    v->Z = z;
 }

--- a/src/main/flight/imu.c
+++ b/src/main/flight/imu.c
@@ -340,17 +340,13 @@ static void imuCalculateEstimatedAttitude(timeUs_t currentTimeUs)
     const timeDelta_t deltaT = currentTimeUs - previousIMUUpdateTime;
     previousIMUUpdateTime = currentTimeUs;
 
-    if (imuIsAccelerometerHealthy()) {
-        useAcc = true;
-    }
-
 #ifdef USE_MAG
     if (sensors(SENSOR_MAG)) {
         useMag = true;
     }
 #endif
 #if defined(USE_GPS)
-    else if (STATE(FIXED_WING) && sensors(SENSOR_GPS) && STATE(GPS_FIX) && gpsSol.numSat >= 5 && gpsSol.groundSpeed >= 300) {
+    if (STATE(FIXED_WING) && sensors(SENSOR_GPS) && STATE(GPS_FIX) && gpsSol.numSat >= 5 && gpsSol.groundSpeed >= 300) {
         // In case of a fixed-wing aircraft we can use GPS course over ground to correct heading
         rawYawError = DECIDEGREES_TO_RADIANS(attitude.values.yaw - gpsSol.groundCourse);
         useYaw = true;

--- a/src/main/flight/imu.h
+++ b/src/main/flight/imu.h
@@ -28,16 +28,6 @@ extern int accSumCount;
 extern float accVelScale;
 extern int32_t accSum[XYZ_AXIS_COUNT];
 
-typedef struct {
-    float w,x,y,z;
-} quaternion;
-#define QUATERNION_INITIALIZE  {.w=1, .x=0, .y=0,.z=0}
-
-typedef struct {
-    float ww,wx,wy,wz,xx,xy,xz,yy,yz,zz;
-} quaternionProducts;
-#define QUATERNION_PRODUCTS_INITIALIZE  {.ww=1, .wx=0, .wy=0, .wz=0, .xx=0, .xy=0, .xz=0, .yy=0, .yz=0, .zz=0}
-
 typedef union {
     int16_t raw[XYZ_AXIS_COUNT];
     struct {
@@ -50,6 +40,7 @@ typedef union {
 #define EULER_INITIALIZE  { { 0, 0, 0 } }
 
 extern attitudeEulerAngles_t attitude;
+extern quaternion qHeadfree;
 
 typedef struct accDeadband_s {
     uint8_t xy;                 // set the acc deadband for xy-Axis
@@ -74,6 +65,13 @@ typedef struct imuRuntimeConfig_s {
     accDeadband_t accDeadband;
 } imuRuntimeConfig_t;
 
+enum {
+    DEBUG_IMU_VGYROMODULUS,
+    DEBUG_IMU_VKPKIMODULUS,
+    DEBUG_IMU_VACCMODULUS,
+    DEBUG_IMU_FREE
+};
+
 void imuConfigure(uint16_t throttle_correction_angle);
 
 float getCosTiltAngle(void);
@@ -91,6 +89,4 @@ void imuSetHasNewData(uint32_t dt);
 #endif
 #endif
 
-void imuQuaternionComputeProducts(quaternion *quat, quaternionProducts *quatProd);
 bool imuQuaternionHeadfreeOffsetSet(void);
-void imuQuaternionHeadfreeTransformVectorEarthToBody(t_fp_vector_def * v);

--- a/src/main/interface/msp.c
+++ b/src/main/interface/msp.c
@@ -787,7 +787,7 @@ static bool mspProcessOutCommand(uint8_t cmdMSP, sbuf_t *dst)
                 sbufWriteU16(dst, gyroRateDps(i));
             }
             for (int i = 0; i < 3; i++) {
-                sbufWriteU16(dst, mag.magADC[i]);
+                sbufWriteU16(dst, lrintf(mag.magADC[i]));
             }
         }
         break;

--- a/src/main/sensors/acceleration.h
+++ b/src/main/sensors/acceleration.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "common/time.h"
+#include "common/maths.h"
 #include "pg/pg.h"
 #include "drivers/accgyro/accgyro.h"
 #include "sensors/sensors.h"
@@ -80,7 +81,8 @@ bool accIsCalibrationComplete(void);
 void accSetCalibrationCycles(uint16_t calibrationCyclesRequired);
 void resetRollAndPitchTrims(rollAndPitchTrims_t *rollAndPitchTrims);
 void accUpdate(timeUs_t currentTimeUs, rollAndPitchTrims_t *rollAndPitchTrims);
-bool accGetAccumulationAverage(float *accumulation);
+bool accGetAverage(quaternion *average);
 union flightDynamicsTrims_u;
 void setAccelerationTrims(union flightDynamicsTrims_u *accelerationTrimsToUse);
 void accInitFilters(void);
+bool accIsHealthy(quaternion *q);

--- a/src/main/sensors/compass.c
+++ b/src/main/sensors/compass.c
@@ -17,9 +17,11 @@
 
 #include <stdbool.h>
 #include <stdint.h>
+#include <math.h>
 
 #include "platform.h"
 
+#include "build/debug.h"
 #include "common/axis.h"
 
 #include "pg/pg.h"
@@ -262,9 +264,11 @@ bool compassInit(void)
     return true;
 }
 
-bool compassIsHealthy(void)
-{
-    return (mag.magADC[X] != 0) && (mag.magADC[Y] != 0) && (mag.magADC[Z] != 0);
+bool compassIsHealthy(quaternion *q) {
+  const float magModulus = quaternionModulus(q);
+
+  //todo findout mag healthy limits
+  return ((100 < magModulus) && (magModulus < 1000));
 }
 
 void compassUpdate(timeUs_t currentTimeUs)
@@ -314,5 +318,13 @@ void compassUpdate(timeUs_t currentTimeUs)
             saveConfigAndNotify();
         }
     }
+}
+
+bool compassGetAverage(quaternion *vAverage) {
+    vAverage->w = 0;
+    vAverage->x = mag.magADC[X];
+    vAverage->y = mag.magADC[Y];
+    vAverage->z = mag.magADC[Z];
+    return(true);
 }
 #endif // USE_MAG

--- a/src/main/sensors/compass.h
+++ b/src/main/sensors/compass.h
@@ -18,6 +18,7 @@
 #pragma once
 
 #include "common/time.h"
+#include "common/maths.h"
 #include "drivers/io_types.h"
 #include "drivers/sensor.h"
 #include "pg/pg.h"
@@ -56,6 +57,8 @@ typedef struct compassConfig_s {
 
 PG_DECLARE(compassConfig_t, compassConfig);
 
-bool compassIsHealthy(void);
+bool compassIsHealthy(quaternion *q);
 void compassUpdate(timeUs_t currentTime);
 bool compassInit(void);
+union flightDynamicsTrims_u;
+bool compassGetAverage(quaternion *vAverage);

--- a/src/main/sensors/gyro.c
+++ b/src/main/sensors/gyro.c
@@ -91,6 +91,7 @@ static FAST_RAM float accumulatedMeasurements[XYZ_AXIS_COUNT];
 static FAST_RAM float gyroPrevious[XYZ_AXIS_COUNT];
 static FAST_RAM timeUs_t accumulatedMeasurementTimeUs;
 static FAST_RAM timeUs_t accumulationLastTimeSampledUs;
+float vGyroStdDevModulus;
 
 typedef struct gyroCalibration_s {
     int32_t sum[XYZ_AXIS_COUNT];
@@ -811,7 +812,6 @@ STATIC_UNIT_TESTED void performGyroCalibration(gyroSensor_t *gyroSensor, uint8_t
                 gyroSetCalibrationCycles(gyroSensor);
                 return;
             }
-
             // please take care with exotic boardalignment !!
             gyroSensor->gyroDev.gyroZero[axis] = gyroSensor->calibration.sum[axis] / gyroCalculateCalibratingCycles();
             if (axis == Z) {
@@ -823,6 +823,13 @@ STATIC_UNIT_TESTED void performGyroCalibration(gyroSensor_t *gyroSensor, uint8_t
     if (isOnFinalGyroCalibrationCycle(&gyroSensor->calibration)) {
         schedulerResetTaskStatistics(TASK_SELF); // so calibration cycles do not pollute tasks statistics
         if (!firstArmingCalibrationWasStarted || (getArmingDisableFlags() & ~ARMING_DISABLED_CALIBRATING) == 0) {
+            // calculate gyro noise standard deviation modulus
+            static quaternion vStdDev = VECTOR_INITIALIZE;
+            vStdDev.x =  devStandardDeviation(&gyroSensor->calibration.var[X]);
+            vStdDev.y =  devStandardDeviation(&gyroSensor->calibration.var[Y]);
+            vStdDev.z =  devStandardDeviation(&gyroSensor->calibration.var[Z]);
+            vGyroStdDevModulus =  quaternionModulus(&vStdDev) / 1000.0f;
+
             beeper(BEEPER_GYRO_CALIBRATED);
         }
     }
@@ -1110,20 +1117,20 @@ FAST_CODE void gyroUpdate(timeUs_t currentTimeUs)
     gyroUpdateSensor(&gyroSensor1, currentTimeUs);
 }
 
-bool gyroGetAccumulationAverage(float *accumulationAverage)
-{
+bool gyroGetAverage(quaternion *vAverage) {
     if (accumulatedMeasurementTimeUs > 0) {
-        // If we have gyro data accumulated, calculate average rate that will yield the same rotation
+        vAverage->w = 0;
+        vAverage->x = DEGREES_TO_RADIANS(accumulatedMeasurements[X] / accumulatedMeasurementTimeUs);
+        vAverage->y = DEGREES_TO_RADIANS(accumulatedMeasurements[Y] / accumulatedMeasurementTimeUs);
+        vAverage->z = DEGREES_TO_RADIANS(accumulatedMeasurements[Z] / accumulatedMeasurementTimeUs);
+
         for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-            accumulationAverage[axis] = accumulatedMeasurements[axis] / accumulatedMeasurementTimeUs;
             accumulatedMeasurements[axis] = 0.0f;
         }
         accumulatedMeasurementTimeUs = 0;
         return true;
     } else {
-        for (int axis = 0; axis < XYZ_AXIS_COUNT; axis++) {
-            accumulationAverage[axis] = 0.0f;
-        }
+        quaternionInitVector(vAverage);
         return false;
     }
 }

--- a/src/main/sensors/gyro.h
+++ b/src/main/sensors/gyro.h
@@ -19,10 +19,12 @@
 
 #include "common/axis.h"
 #include "common/time.h"
+#include "common/maths.h"
 #include "pg/pg.h"
 #include "drivers/bus.h"
 #include "drivers/sensor.h"
 
+extern float vGyroStdDevModulus;
 typedef enum {
     GYRO_NONE = 0,
     GYRO_DEFAULT,
@@ -103,7 +105,7 @@ void gyroDmaSpiFinishRead(void);
 void gyroDmaSpiStartRead(void);
 #endif
 void gyroUpdate(timeUs_t currentTimeUs);
-bool gyroGetAccumulationAverage(float *accumulation);
+bool gyroGetAverage(quaternion *vAverage);
 const busDevice_t *gyroSensorBus(void);
 struct mpuConfiguration_s;
 const struct mpuConfiguration_s *gyroMpuConfiguration(void);

--- a/src/test/unit/flight_imu_unittest.cc
+++ b/src/test/unit/flight_imu_unittest.cc
@@ -51,11 +51,7 @@ extern "C" {
     #include "sensors/gyro.h"
     #include "sensors/sensors.h"
 
-    void imuComputeRotationMatrix(void);
     void imuUpdateEulerAngles(void);
-
-    extern quaternion q;
-    extern float rMat[3][3];
 
     PG_REGISTER(rcControlsConfig_t, rcControlsConfig, PG_RC_CONTROLS_CONFIG, 0);
     PG_REGISTER(barometerConfig_t, barometerConfig, PG_BAROMETER_CONFIG, 0);
@@ -68,137 +64,13 @@ extern "C" {
 #include "unittest_macros.h"
 #include "gtest/gtest.h"
 
-const float sqrt2over2 = sqrt(2) / 2.0f;
-
-TEST(FlightImuTest, TestCalculateRotationMatrix)
-{
-    #define TOL 1e-6
-
-    // No rotation
-    q.w = 1.0f;
-    q.x = 0.0f;
-    q.y = 0.0f;
-    q.z = 0.0f;
-
-    imuComputeRotationMatrix();
-
-    EXPECT_FLOAT_EQ(1.0f, rMat[0][0]);
-    EXPECT_FLOAT_EQ(0.0f, rMat[0][1]);
-    EXPECT_FLOAT_EQ(0.0f, rMat[0][2]);
-    EXPECT_FLOAT_EQ(0.0f, rMat[1][0]);
-    EXPECT_FLOAT_EQ(1.0f, rMat[1][1]);
-    EXPECT_FLOAT_EQ(0.0f, rMat[1][2]);
-    EXPECT_FLOAT_EQ(0.0f, rMat[2][0]);
-    EXPECT_FLOAT_EQ(0.0f, rMat[2][1]);
-    EXPECT_FLOAT_EQ(1.0f, rMat[2][2]);
-
-    // 90 degrees around Z axis
-    q.w = sqrt2over2;
-    q.x = 0.0f;
-    q.y = 0.0f;
-    q.z = sqrt2over2;
-
-    imuComputeRotationMatrix();
-
-    EXPECT_NEAR(0.0f, rMat[0][0], TOL);
-    EXPECT_NEAR(-1.0f, rMat[0][1], TOL);
-    EXPECT_NEAR(0.0f, rMat[0][2], TOL);
-    EXPECT_NEAR(1.0f, rMat[1][0], TOL);
-    EXPECT_NEAR(0.0f, rMat[1][1], TOL);
-    EXPECT_NEAR(0.0f, rMat[1][2], TOL);
-    EXPECT_NEAR(0.0f, rMat[2][0], TOL);
-    EXPECT_NEAR(0.0f, rMat[2][1], TOL);
-    EXPECT_NEAR(1.0f, rMat[2][2], TOL);
-
-    // 60 degrees around X axis
-    q.w = 0.866f;
-    q.x = 0.5f;
-    q.y = 0.0f;
-    q.z = 0.0f;
-
-    imuComputeRotationMatrix();
-
-    EXPECT_NEAR(1.0f, rMat[0][0], TOL);
-    EXPECT_NEAR(0.0f, rMat[0][1], TOL);
-    EXPECT_NEAR(0.0f, rMat[0][2], TOL);
-    EXPECT_NEAR(0.0f, rMat[1][0], TOL);
-    EXPECT_NEAR(0.5f, rMat[1][1], TOL);
-    EXPECT_NEAR(-0.866f, rMat[1][2], TOL);
-    EXPECT_NEAR(0.0f, rMat[2][0], TOL);
-    EXPECT_NEAR(0.866f, rMat[2][1], TOL);
-    EXPECT_NEAR(0.5f, rMat[2][2], TOL);
-}
-
-TEST(FlightImuTest, TestUpdateEulerAngles)
-{
-    // No rotation
-    memset(rMat, 0.0, sizeof(float) * 9);
-
-    imuUpdateEulerAngles();
-
-    EXPECT_EQ(0, attitude.values.roll);
-    EXPECT_EQ(0, attitude.values.pitch);
-    EXPECT_EQ(0, attitude.values.yaw);
-
-    // 45 degree yaw
-    memset(rMat, 0.0, sizeof(float) * 9);
-    rMat[0][0] = sqrt2over2;
-    rMat[0][1] = sqrt2over2;
-    rMat[1][0] = -sqrt2over2;
-    rMat[1][1] = sqrt2over2;
-
-    imuUpdateEulerAngles();
-
-    EXPECT_EQ(0, attitude.values.roll);
-    EXPECT_EQ(0, attitude.values.pitch);
-    EXPECT_EQ(450, attitude.values.yaw);
-}
-
-TEST(FlightImuTest, TestSmallAngle)
-{
-    const float r1 = 0.898;
-    const float r2 = 0.438;
-
-    // given
-    imuConfigMutable()->small_angle = 25;
-
-    // and
-    memset(rMat, 0.0, sizeof(float) * 9);
-
-    // when
-    imuUpdateEulerAngles();
-
-    // expect
-    EXPECT_EQ(0, STATE(SMALL_ANGLE));
-
-    // given
-    rMat[0][0] = r1;
-    rMat[0][2] = r2;
-    rMat[2][0] = -r2;
-    rMat[2][2] = r1;
-
-    // when
-    imuUpdateEulerAngles();
-
-    // expect
-    EXPECT_EQ(SMALL_ANGLE, STATE(SMALL_ANGLE));
-
-    // given
-    memset(rMat, 0.0, sizeof(float) * 9);
-
-    // when
-    imuUpdateEulerAngles();
-
-    // expect
-    EXPECT_EQ(0, STATE(SMALL_ANGLE));
-}
-
 // STUBS
 
 extern "C" {
 boxBitmask_t rcModeActivationMask;
 float rcCommand[4];
 int16_t rcData[MAX_SUPPORTED_RC_CHANNEL_COUNT];
+float vGyroStdDevModulus;
 
 gyro_t gyro;
 acc_t acc;
@@ -234,10 +106,13 @@ bool sensors(uint32_t mask)
 uint32_t millis(void) { return 0; }
 uint32_t micros(void) { return 0; }
 
-bool compassIsHealthy(void) { return true; }
+bool compassIsHealthy(quaternion *) { return true; }
 bool isBaroCalibrationComplete(void) { return true; }
 void performBaroCalibrationCycle(void) {}
 int32_t baroCalculateAltitude(void) { return 0; }
-bool gyroGetAccumulationAverage(float *) { return false; }
-bool accGetAccumulationAverage(float *) { return false; }
+bool gyroGetAverage(quaternion *) { return false; }
+bool accGetAverage(quaternion *) { return false; }
+bool accIsHealthy(quaternion *) { return false; }
+bool compassGetAverage(quaternion *) { return false; }
+bool isBeeperOn(void){ return true; }
 }


### PR DESCRIPTION
phase out rmat (use quaternion)

implemented static gyro noise integration lock  trough standard deviation modulus
improved gyro Integration (PCDM Acta Mech 224, 3091–3109 (2013))
separated from Mahony PI
corrected acc
corrected gyro
increased default dcm_ki dcm_kp for faster convergence
removed ATTITUDE task rescheduling
